### PR TITLE
standardize gadget name

### DIFF
--- a/src/Gadget/SecurityCheckerGadget.php
+++ b/src/Gadget/SecurityCheckerGadget.php
@@ -74,7 +74,7 @@ class SecurityCheckerGadget implements GadgetInterface
      */
     public function getName()
     {
-        return 'security-checker';
+        return 'security_checker';
     }
 
     /**


### PR DESCRIPTION
we should standardize gadget names. i think with underscore as separator is the best choice.