### PR TITLE
Only metrics with an output

### DIFF
--- a/src/Formatter/Adapter/SummaryAdapter.php
+++ b/src/Formatter/Adapter/SummaryAdapter.php
@@ -35,6 +35,11 @@ class SummaryAdapter implements AdapterInterface
             );
         }, $issues));
 
+        foreach ($metrics as $key => $metric) {
+            if ($metric->getValue() == 0) {
+                unset($metrics[$key]);
+            }
+        }
 
         $markdown->h1(count($metrics) . ' Metric(s)');
 

--- a/src/Formatter/Adapter/SummaryAdapter.php
+++ b/src/Formatter/Adapter/SummaryAdapter.php
@@ -35,11 +35,9 @@ class SummaryAdapter implements AdapterInterface
             );
         }, $issues));
 
-        foreach ($metrics as $key => $metric) {
-            if ($metric->getValue() == 0) {
-                unset($metrics[$key]);
-            }
-        }
+        $metrics = array_filter($metrics, function (Metric $metric) {
+            return $metric->getValue() > 0;
+        });
 
         $markdown->h1(count($metrics) . ' Metric(s)');
 


### PR DESCRIPTION
Just an little improvement  on output, perhaps its useless... but for phpstorm its great to have lesser output. It only shows metrics data with values > 0.