### PR TITLE
Updated dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
     },
     "require": {
         "php": ">=5.4",
-        "symfony/console": "~2.6",
-        "symfony/event-dispatcher": "~2.6",
-        "symfony/yaml": "~2.6",
-        "symfony/options-resolver": "~2.6",
-        "symfony/finder": "~2.6",
-        "symfony/process": "~2.6",
-        "symfony/serializer": "~2.6",
-        "symfony/dependency-injection": "~2.6",
-        "symfony/config": "~2.6",
+        "symfony/console": "~2.7",
+        "symfony/event-dispatcher": "~2.7",
+        "symfony/yaml": "~2.7",
+        "symfony/options-resolver": "~2.7",
+        "symfony/finder": "~2.7",
+        "symfony/process": "~2.7",
+        "symfony/serializer": "~2.7",
+        "symfony/dependency-injection": "~2.7",
+        "symfony/config": "~2.7",
         "pdepend/pdepend": "~2.0.4",
         "phpmd/phpmd": "~2.1",
         "squizlabs/php_codesniffer": "~2.0",
@@ -26,15 +26,14 @@
         "nikic/php-parser": "~1.2.0",
         "simpspector/twig-lint": "~1.1",
         "davidbadura/markdown-builder": "~1.0.3",
-        "jms/serializer": "0.16.*",
+        "jms/serializer": "~1.0",
         "webmozart/path-util": "^2.0",
-        "symfony/config": "~2.6",
         "phpunit/php-token-stream": "1.*",
         "phpdocumentor/reflection-docblock": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/var-dumper": "~2.6"
+        "symfony/var-dumper": "~2.7"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
Symfony 2.6 ist not supported anymore and updated jms/serializer to be compatible with newer PHP versions.